### PR TITLE
Fixed single laser scanning

### DIFF
--- a/src/horus/engine/scan/current_video.py
+++ b/src/horus/engine/scan/current_video.py
@@ -46,8 +46,9 @@ class CurrentVideo(object):
 
     def set_line(self, points, image):
         images = [None, None]
-        images[0] = self._compute_line_image(points[0], image)
-        images[1] = self._compute_line_image(points[1], image)
+        for i in xrange(2):
+          if points[i]:
+            images[i] = self._compute_line_image(points[i], image)
         image = self._combine_images(images)
         image = cv2.merge((image, image, image))
         image = self._apply_roi(image)


### PR DESCRIPTION
Currently single laser scanning is crashing while processing points data with error backtrace like below:

```
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/threading.py", line 813, in __bootstrap_inner
    self.run()
  File "/usr/lib64/python2.7/threading.py", line 766, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/avm/bin/horus/lib/python2.7/site-packages/Horus-0.2-py2.7.egg/horus/src/horus/engine/scan/ciclop_scan.py", line 185, in _process
    self.current_video.set_line(points, image)
  File "/home/avm/bin/horus/lib/python2.7/site-packages/Horus-0.2-py2.7.egg/horus/src/horus/engine/scan/current_video.py", line 49, in set_line
    images[0] = self._compute_line_image(points[0], image)
  File "/home/avm/bin/horus/lib/python2.7/site-packages/Horus-0.2-py2.7.egg/horus/src/horus/engine/scan/current_video.py", line 67, in _compute_line_image
    u, v = points
TypeError: 'NoneType' object is not iterable
```

This patch fixes processing of points data in single laser mode.
