### PR TITLE
update links from github.com/bqlabs to github.com/LibreScanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Horus
 
-[![R&D](https://img.shields.io/badge/-R%26D-brightgreen.svg)](https://github.com/bqlabs/horus)
+[![R&D](https://img.shields.io/badge/-R%26D-brightgreen.svg)](https://github.com/LibreScanner/horus)
 [![License](http://img.shields.io/:license-gpl-blue.svg)](http://opensource.org/licenses/GPL-2.0)
 [![Documentation Status](https://readthedocs.org/projects/horus/badge/?version=release-0.2)](http://horus.readthedocs.io/en/release-0.2/?badge=release-0.2)
 
-Horus is a general solution for 3D laser scanning. It provides graphic user interfaces for connection, configuration, control, calibration and scanning with Open Source [Ciclop 3D Scanner](https://github.com/bqlabs/ciclop).
+Horus is a general solution for 3D laser scanning. It provides graphic user interfaces for connection, configuration, control, calibration and scanning with Open Source [Ciclop 3D Scanner](https://github.com/LibreScanner/ciclop).
 
 This is a research project to explore the 3D laser scan with free tools. Feel free to use it for experiments, modify and adapt it to new devices and contribute new features or ideas.
 

--- a/doc/development/ubuntu.md
+++ b/doc/development/ubuntu.md
@@ -96,7 +96,7 @@ or
 git clone git@github.com:bq/opencv.git
 ```
 
-And build it your own: [instructions](https://github.com/bqlabs/opencv/wiki/Build)
+And build it your own: [instructions](https://github.com/LibreScanner/opencv/wiki/Build)
 
 ## 3. Execute source code
 

--- a/doc/installation/debian.md
+++ b/doc/installation/debian.md
@@ -8,7 +8,7 @@ Versions: 8
 
 However it can be installed following the next instructions.
 
-First you need to build and install our [custom OpenCV](https://github.com/bqlabs/opencv/wiki/Build)
+First you need to build and install our [custom OpenCV](https://github.com/LibreScanner/opencv/wiki/Build)
 
 Then, generate the executable file following the next [instructions](../development/ubuntu.md).
 

--- a/doc/readthedocs/locale/en/LC_MESSAGES/source.po
+++ b/doc/readthedocs/locale/en/LC_MESSAGES/source.po
@@ -638,7 +638,7 @@ msgstr ""
 #: ../../source/scanner-components/board.rst:25
 msgid ""
 "The firmware is an adaptation of Grbl. Source code is here: "
-"https://github.com/bqlabs/horus-fw."
+"https://github.com/LibreScanner/horus-fw."
 msgstr ""
 
 #: ../../source/scanner-components/board.rst:27

--- a/doc/readthedocs/locale/es/LC_MESSAGES/source.po
+++ b/doc/readthedocs/locale/es/LC_MESSAGES/source.po
@@ -745,10 +745,10 @@ msgstr "Horus Firmware"
 #: ../../source/scanner-components/board.rst:25
 msgid ""
 "The firmware is an adaptation of Grbl. Source code is here: https://github."
-"com/bqlabs/horus-fw."
+"com/LibreScanner/horus-fw."
 msgstr ""
 "El firmware es una adaptación de Grbl. El código fuente está aquí: https://"
-"github.com/bqlabs/horus-fw."
+"github.com/LibreScanner/horus-fw."
 
 #: ../../source/scanner-components/board.rst:27
 msgid "It can be uploaded in **Preferences > Upload firmware**."

--- a/doc/readthedocs/source/getting-started/index.rst
+++ b/doc/readthedocs/source/getting-started/index.rst
@@ -11,7 +11,7 @@ It provides a graphical interface that allows you to connect the scanner, contro
 
 It was created by `bqlabs`_, the Department of Innovation and Robotics at `BQ`_, developed in `Python`_ and released under the `GPLv2`_ license.
 
-.. _open 3D scanner Ciclop: https://github.com/bqlabs/ciclop
+.. _open 3D scanner Ciclop: https://github.com/LibreScanner/ciclop
 .. _bqlabs: https://github.com/bqlabs
 .. _BQ: http://www.bq.com
 .. _Python: https://www.python.org/

--- a/doc/readthedocs/source/installation/macosx.rst
+++ b/doc/readthedocs/source/installation/macosx.rst
@@ -28,4 +28,4 @@ Reboot the computer to apply the changes.
 
 
 .. _FTDI USB Drivers: http://www.ftdichip.com/Drivers/VCP/MacOSX/FTDIUSBSerialDriver_v2_3.dmg
-.. _Horus installer: https://github.com/bqlabs/horus/releases/download/0.2rc1/Horus_0.2rc1.dmg
+.. _Horus installer: https://github.com/LibreScanner/horus/releases/download/0.2rc1/Horus_0.2rc1.dmg

--- a/doc/readthedocs/source/installation/ubuntu.rst
+++ b/doc/readthedocs/source/installation/ubuntu.rst
@@ -52,5 +52,5 @@ If there is a new release just execute
 
 .. _PPA Horus: https://launchpad.net/~bqlabs/+archive/ubuntu/horus/
 .. _PPA Horus dev: https://launchpad.net/~bqlabs/+archive/ubuntu/horus-dev/
-.. _custom OpenCV: https://github.com/bqlabs/opencv
-.. _reasons: https://github.com/bqlabs/opencv/wiki
+.. _custom OpenCV: https://github.com/LibreScanner/opencv
+.. _reasons: https://github.com/LibreScanner/opencv/wiki

--- a/doc/readthedocs/source/installation/windows.rst
+++ b/doc/readthedocs/source/installation/windows.rst
@@ -36,4 +36,4 @@ Reboot the computer to apply the changes.
    4. *Apply* and close the window.
 
 .. _Logitech Camera C270 Drivers: http://support.logitech.com/en_us/product/hd-webcam-c270
-.. _Horus installer: https://github.com/bqlabs/horus/releases/download/0.2rc1/Horus_0.2rc1.exe
+.. _Horus installer: https://github.com/LibreScanner/horus/releases/download/0.2rc1/Horus_0.2rc1.exe

--- a/doc/readthedocs/source/scanner-components/board.rst
+++ b/doc/readthedocs/source/scanner-components/board.rst
@@ -22,7 +22,7 @@ ZUM SCAN Shield
 Horus Firmware
 --------------
 
-The firmware is an adaptation of Grbl. Source code is here: https://github.com/bqlabs/horus-fw.
+The firmware is an adaptation of Grbl. Source code is here: https://github.com/LibreScanner/horus-fw.
 
 It can be uploaded in **Preferences > Upload firmware**.
 

--- a/doc/readthedocs/source/scanner-components/camera.rst
+++ b/doc/readthedocs/source/scanner-components/camera.rst
@@ -163,6 +163,6 @@ Focus image
    In this `video`_ the camera manual focus is explained.
 
 
-.. _custom OpenCV: https://github.com/bqlabs/opencv
-.. _reasons: https://github.com/bqlabs/opencv/wiki
+.. _custom OpenCV: https://github.com/LibreScanner/opencv
+.. _reasons: https://github.com/LibreScanner/opencv/wiki
 .. _video: https://www.youtube.com/watch?v=v-gYgBeiOVI

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
 
     license='GPLv2',
     keywords="horus ciclop scanning 3d",
-    url='https://github.com/bqlabs/horus',
+    url='https://github.com/LibreScanner/horus',
 
     packages=find_packages('src'),
     package_dir={'': 'src'},

--- a/src/horus/gui/main.py
+++ b/src/horus/gui/main.py
@@ -181,7 +181,7 @@ class MainWindow(wx.Frame):
         if profile.settings['check_for_updates']:
             self.Bind(wx.EVT_MENU, self.on_updates, self.menu_updates)
         self.Bind(wx.EVT_MENU, lambda e: webbrowser.open(
-            'https://github.com/bqlabs/horus'), self.menu_sources)
+            'https://github.com/LibreScanner/horus'), self.menu_sources)
 
     def on_launch_wizard(self, event):
         self.workbench[profile.settings['workbench']].on_close()


### PR DESCRIPTION
Fixing the broken installer links in the documentation for [Windows](https://horus.readthedocs.io/en/release-0.2/source/installation/windows.html) and [Mac](https://horus.readthedocs.io/en/release-0.2/source/installation/macosx.html). I also updated some other links while I was at it.